### PR TITLE
Include additional info in meta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 Makefile
 pm_to_blib
 blib
+MYMETA.json
+MYMETA.yml

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,6 +24,7 @@ WriteMakefile(
 			license    => 'http://dev.perl.org/licenses/',
 		},
 	},
+	'MIN_PERL_VERSION' => '5.00503',
 );
 
 sub configure {


### PR DESCRIPTION
Going off of http://cpants.cpanauthors.org/dist/Device-Modem, I thought it might be useful to include the minimum Perl version within the mainfest itself.
